### PR TITLE
Feat: Enable alerts to slack

### DIFF
--- a/prometheus/prom-values.yaml
+++ b/prometheus/prom-values.yaml
@@ -777,7 +777,7 @@ scrapeConfigFiles: []
 serverFiles:
   ## Alerts configuration
   ## Ref: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
-  alerting_rules.yml: {}
+  alerting_rules.yml:
   # groups:
   #   - name: Instances
   #     rules:
@@ -790,6 +790,49 @@ serverFiles:
   #           description: '{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 5 minutes.'
   #           summary: 'Instance {{ $labels.instance }} down'
   ## DEPRECATED DEFAULT VALUE, unless explicitly naming your files, please use alerting_rules.yml
+    groups:
+      - name: prom_alerts
+        rules:
+          # CPU Usage Alert
+          - alert: HighCPUUsage
+            expr: sum(rate(container_cpu_usage_seconds_total[1m])) by (pod) > 0.5
+            for: 2m
+            labels:
+              severity: warning
+            annotations:
+              description: "High CPU usage detected for pod {{ $labels.pod }}. Usage: {{ $value }} cores."
+              summary: "Pod {{ $labels.pod }} is using high CPU ({{ $value }} cores)."
+
+          # Memory Usage Alert
+          - alert: HighMemoryUsage
+            expr: sum(container_memory_working_set_bytes) by (pod) > 700 * 1024 * 1024  # 700 MB
+            for: 2m
+            labels:
+              severity: warning
+            annotations:
+              description: "High memory usage detected for pod {{ $labels.pod }}. Usage: {{ $value | humanize1024 }}."
+              summary: "Pod {{ $labels.pod }} is using high memory ({{ $value | humanize1024 }})."
+
+          # Network Receive Alert
+          - alert: HighNetworkReceive
+            expr: sum(rate(container_network_receive_bytes_total[1m])) by (pod) > 10 * 1024 * 1024  # 10 MB/s
+            for: 2m
+            labels:
+              severity: warning
+            annotations:
+              description: "High network receive traffic detected for pod {{ $labels.pod }}. Usage: {{ $value | humanize1024 }}/s."
+              summary: "Pod {{ $labels.pod }} is receiving high network traffic ({{ $value | humanize1024 }}/s)."
+
+          # Network Transmit Alert
+          - alert: HighNetworkTransmit
+            expr: sum(rate(container_network_transmit_bytes_total[1m])) by (pod) > 10 * 1024 * 1024  # 10 MB/s
+            for: 2m
+            labels:
+              severity: warning
+            annotations:
+              description: "High network transmit traffic detected for pod {{ $labels.pod }}. Usage: {{ $value | humanize1024 }}/s."
+              summary: "Pod {{ $labels.pod }} is sending high network traffic ({{ $value | humanize1024 }}/s)."
+
   alerts: {}
 
   ## Records configuration
@@ -1327,6 +1370,23 @@ alertmanager:
     runAsNonRoot: true
     runAsGroup: 65534
     fsGroup: 65534
+    
+  config:
+    global:
+      resolve_timeout: 5m
+    route:
+      group_by: ['prom_alerts']
+      group_wait: 30s
+      group_interval: 1h
+      repeat_interval: 1h
+      receiver: 'slack-receiver'
+    receivers:
+      - name: 'slack-receiver'
+        slack_configs:
+          - send_resolved: true
+            api_url: 'https://hooks.slack.com/services/xxx/xxxx/xxxx'
+            channel: '#prom-alerts'
+            text: "{{ range .Alerts }}*Alert:* {{ .Labels.prom_alerts}}\n*Description:* {{ .Annotations.description }}\n*Severity:* {{ .Labels.severity }}\n{{ end }}"
 
 ## kube-state-metrics sub-chart configurable values
 ## Please see https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics


### PR DESCRIPTION
This PR enables the alert manager to send notifications to slack in case of too much usage of resources